### PR TITLE
remove non-empty token requirment for service registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ plugins:  # Plugin configurations.
       # service:  # Services to be registered.
       #   - name: trpc.server.Service1  # Service name, should keep consistent with service in server config in trpc_go.yaml.
       #     namespace: Development  # The namespace this service belongs to.
-      #     token: xxxxxxxxxxxxxxxxxxx  # Apply your token in polaris mesh console.
       #     # (Optional) Used to heartbeat or unregister.
       #     # When register_self is true, this config has no effect, the plugin will use returned instance_id of register to overwrite config.
       #     # if register_self is false, instance_id cannot be missing.

--- a/registry/README.md
+++ b/registry/README.md
@@ -20,7 +20,6 @@ plugins:  # tRPC-Go plugin configuration.
       service:
         - name:  trpc.test.helloworld.Greeter1  # The name of service.
           namespace: namespace-test1  # The namespace of your service.
-          token: xxxxxxxxxxxxxxxxxxxx  # Token is optional for service registration.
           # (Optional) Used to heartbeat or unregister.
           # When register_self is true, this config has no effect, the plugin will use returned instance_id of register to overwrite config.
           # if register_self is false, instance_id cannot be missing.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -48,9 +48,6 @@ type Registry struct {
 
 // newRegistry is to new an instance.
 func newRegistry(provider api.ProviderAPI, cfg *Config) (*Registry, error) {
-	if len(cfg.ServiceToken) == 0 {
-		return nil, fmt.Errorf("service: %s, token can not be empty", cfg.ServiceName)
-	}
 	if cfg.HeartBeat == 0 {
 		cfg.HeartBeat = defaultHeartBeat
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -78,12 +78,7 @@ plugins:
 
 func TestNew(t *testing.T) {
 	_, err := newRegistry(nil, &Config{})
-	assert.NotNil(t, err)
-
-	_, err = newRegistry(nil, &Config{
-		ServiceToken: "token",
-	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestRegisterDeRegister(t *testing.T) {


### PR DESCRIPTION
Related to #14 
Token is the legacy code within the internal. Opensource polaris does not supports multitenancy, so, there is no need for a token.