### PR TITLE
feat: allow overwriting bind_address by polarismesh service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ plugins:  # Plugin configurations.
       #     instance_id: yyyyyyyyyyyyyyyy
       #     weight: 100  # Set weight.
       #     bind_address: eth1:8080  # (optional) set listen addr, use the addr in service as default.
+      #     prefer_bind_address: true  # (optional) give bind_address priority over addr in service if true. Default as false.
       #     metadata:  # The user defined metadata.
       #       internal-enable-set: Y  # Enable set, (both this line and the next line need to be set to fully enable set).
       #       internal-set-name: xx.yy.sz  # Enable set name.

--- a/registry/config.go
+++ b/registry/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	ServiceName string
 	// BindAddress specifies reporting address.
 	BindAddress string
+	// PreferBindAddress gives the BindAddress higher priority over service TRPC's opts.Address when it is true.
+	PreferBindAddress bool
 	// Metadata User-defined metadata information.
 	Metadata map[string]string
 	// DisableHealthCheck disables healthcheck.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -17,6 +17,7 @@ package registry
 import (
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -91,10 +92,13 @@ func (r *Registry) Register(_ string, opt ...registry.Option) error {
 	for _, o := range opt {
 		o(opts)
 	}
-	address := r.cfg.BindAddress
-	if opts.Address != "" {
-		address = opts.Address
+
+	address := opts.Address
+	if address == "" || r.cfg.PreferBindAddress {
+		address = r.cfg.BindAddress
+		address = os.ExpandEnv(address) // also allow environ
 	}
+
 	host, portRaw, _ := net.SplitHostPort(address)
 	port, _ := strconv.ParseInt(portRaw, 10, 64)
 	r.host = host

--- a/registry/registry_factory.go
+++ b/registry/registry_factory.go
@@ -59,13 +59,14 @@ type ClusterService struct {
 
 // Service is service configuration.
 type Service struct {
-	Namespace   string            `yaml:"namespace"`
-	ServiceName string            `yaml:"name"`
-	Token       string            `yaml:"token"`
-	InstanceID  string            `yaml:"instance_id"`
-	Weight      *int              `yaml:"weight"`
-	BindAddress string            `yaml:"bind_address"`
-	MetaData    map[string]string `yaml:"metadata"`
+	Namespace         string            `yaml:"namespace"`
+	ServiceName       string            `yaml:"name"`
+	Token             string            `yaml:"token"`
+	InstanceID        string            `yaml:"instance_id"`
+	Weight            *int              `yaml:"weight"`
+	BindAddress       string            `yaml:"bind_address"`
+	PreferBindAddress bool              `yaml:"prefer_bind_address"`
+	MetaData          map[string]string `yaml:"metadata"`
 }
 
 func init() {
@@ -162,6 +163,7 @@ func register(provider api.ProviderAPI, conf *FactoryConfig) error {
 			InstanceID:         service.InstanceID,
 			Metadata:           service.MetaData,
 			BindAddress:        service.BindAddress,
+			PreferBindAddress:  service.PreferBindAddress,
 			Weight:             service.Weight,
 			DisableHealthCheck: conf.DisableHealthCheck,
 			InstanceLocation:   conf.InstanceLocation,


### PR DESCRIPTION
Related to https://github.com/trpc-ecosystem/go-naming-polarismesh/issues/16.

Allows increasing the priority of `plugins.registry.polarismesh[n].bind_address` over `opts.Address`, but keeping backward compatibility.

---

I have read the CLA Document and I hereby sign the CLA

---