### PR TITLE
docs: fix link to Chinese Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-English | [中文](README_zh_CN.md)
+English | [中文](README.zh_CN.md)
 
 # tRPC-Go naming polarismesh plugin
 


### PR DESCRIPTION
The link from default README.md to README.zh_CN.md is broken.